### PR TITLE
Correct Used with the contents of meminfo.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Package procmeminfo provides an interface for /proc/meminfo
 
     meminfo.Total() // Total memory size in bytes
     meminfo.Free() // Free Memory (Free + Cached + Buffers)
-    meminfo.Used() // Total - Used
+    meminfo.Used() // Total - Free
 ```
 
 


### PR DESCRIPTION
Hi! it seems that there's a small tipo in the readme but it is correct in the source comments. 

Over to you